### PR TITLE
Github Actions for adding the hacktoberfest labels to newly created issues

### DIFF
--- a/.github/workflows/hacktoberfest-issue-labels.yml
+++ b/.github/workflows/hacktoberfest-issue-labels.yml
@@ -1,0 +1,21 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['hacktoberfest', 'hacktoberfest2023']
+            })


### PR DESCRIPTION
###  Description
Added GitHub workflow to tag a newly created issues in the repository with a Hacktoberfest labels.

### Linked Issue
fixes #8 